### PR TITLE
Fix manifest and add README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,29 @@
+# SynclerV2 Vendor
+
+This repository contains a provider package for Syncler TV. The `GayPornScraper` provider scrapes several pornographic websites for playable video links.
+
+## Files
+
+- `GayPornScraper.json` – Provider manifest consumed by Syncler.
+- `manifest.GayPornScraper.json` – Package manifest for distributing the provider.
+- `scraper.js` – The search and resolve logic used by Syncler.
+
+## Usage
+
+Add the `permaUrl` from `GayPornScraper.json` to Syncler to load this package.
+
+```
+https://raw.githubusercontent.com/donatelloroberto/SynclerV2vendor/main/GayPornScraper.json
+```
+
+## Development
+
+You can execute the scraper locally with Node.js (v18+ required) to test the `search` function:
+
+
+Note: Node.js does not provide DOMParser by default. Install `jsdom` if running outside the Syncler environment.
+```bash
+node -e "const {search}=require('./scraper'); search('query','manporn').then(r=>console.log(r))"
+```
+
+Internet access may be required for full results.

--- a/manifest.GayPornScraper.json
+++ b/manifest.GayPornScraper.json
@@ -3,8 +3,8 @@
     "name": "GayPornScraper",
     "id": "GayPorn.Sites",
     "version": 2,
-    "classPath": "bouncy.BouncyProviderPackage",
-    "permaUrl": "https://example.com/GayPornScraper.json"
+    "classPath": "GayPornScraper",
+    "permaUrl": "https://raw.githubusercontent.com/donatelloroberto/SynclerV2vendor/main/GayPornScraper.json"
   },
   "providers": [
     {


### PR DESCRIPTION
## Summary
- update manifest with correct class path and perma URL
- document the repository and how to use the vendor

## Testing
- `node - <<'NODE'
const {search} = require('./scraper.js');
const {JSDOM} = require('jsdom');
DOMParser = new JSDOM().window.DOMParser;
fetch = async () => ({ok:true, text: async()=>`<html><body><article class='post'><h2>Title</h2><a rel='bookmark' href='https://example.com/video'></a><img src='thumb.jpg'/><span class='duration'>5 min</span></article></body></html>`});
search('query','manporn').then(r=>console.log('result',r[0]));
NODE`

------
https://chatgpt.com/codex/tasks/task_e_6886aee0a5f4832cb9dfd2f4264edc1b